### PR TITLE
feat: prevent accidental exposure of sensitive info and bump version

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: .
   specs:
-    woocommerce-ruby3-api (1.5.2)
+    woocommerce-ruby3-api (1.5.3)
       addressable (~> 2.8.1)
       base64 (~> 0.2.0)
       httparty (~> 0.23.1)

--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 A Ruby wrapper for the WooCommerce REST API. Easily interact with the WooCommerce REST API using this library, optimized for Ruby 3.0+.
 
-[![Gem Version](https://badge.fury.io/rb/woocommerce-ruby3-api.svg?bust=2)](https://badge.fury.io/rb/woocommerce-ruby3-api)
+[![Gem Version](https://badge.fury.io/rb/woocommerce-ruby3-api.svg?bust=3)](https://badge.fury.io/rb/woocommerce-ruby3-api)
 [![Tests](https://github.com/chemica/woocommerce-ruby3-api/actions/workflows/test.yml/badge.svg?branch=main&bust=1)](https://github.com/chemica/woocommerce-ruby3-api/actions/workflows/test.yml)
 
 ## About
@@ -208,6 +208,7 @@ puts response.headers["x-wc-totalpages"] # Total of pages
 ## Release History
 
 ### Ruby 3 Version (woocommerce-ruby3-api)
+- 2025-04-11 - 1.5.3 - Hides sensitive information from ruby "inspect". Prevents accidental exposure in logs or console output.
 - 2025-04-11 - 1.5.2 - Fixes gemfile.lock issue.
 - 2025-04-11 - 1.5.1 - Adds RuboCop for code quality. Fixes RuboCop violations. Refactors code and tests for easier maintainability.
 - 2025-04-10 - 1.5.0 - Update code for Ruby 3.1+ compatibility using Addressable::URI and base64 gem. Add Github CI actions.

--- a/lib/woocommerce_api.rb
+++ b/lib/woocommerce_api.rb
@@ -11,15 +11,12 @@ require "woocommerce_api/version"
 module WooCommerce
   class ApiBase
     DEFAULT_ARGS = {
-      wp_api: false,
-      version: "v3",
-      verify_ssl: true,
-      signature_method: "HMAC-SHA256",
-      httparty_args: {}
+      wp_api: false, version: "v3", verify_ssl: true,
+      signature_method: "HMAC-SHA256", httparty_args: {}
     }.freeze
+    SENSITIVE_ARGS = [:@consumer_key, :@consumer_secret, :@signature_method].freeze
 
     def initialize(url, consumer_key, consumer_secret, args = {})
-      # Required args
       @url = url
       @consumer_key = consumer_key
       @consumer_secret = consumer_secret
@@ -27,8 +24,19 @@ module WooCommerce
       args = DEFAULT_ARGS.merge(args)
       create_args_variables(args)
 
-      # Internal args
       @is_ssl = @url.start_with? "https"
+    end
+
+    # Overrides inspect to hide sensitive information
+    #
+    # Returns a string representation of the object
+    def inspect
+      safe_ivars = instance_variables.each_with_object({}) do |var, hash|
+        value = instance_variable_get(var)
+        hash[var] = SENSITIVE_ARGS.include?(var) ? "[FILTERED]" : value
+      end
+
+      "#<#{self.class}:0x#{object_id.to_s(16)} #{safe_ivars.map { |k, v| "#{k}=#{v.inspect}" }.join(', ')}>"
     end
 
     private

--- a/lib/woocommerce_api/version.rb
+++ b/lib/woocommerce_api/version.rb
@@ -1,5 +1,5 @@
 # frozen_string_literal: true
 
 module WooCommerce
-  VERSION = "1.5.2"
+  VERSION = "1.5.3"
 end

--- a/test/woo_commerce_api_test.rb
+++ b/test/woo_commerce_api_test.rb
@@ -9,12 +9,6 @@ class WooCommerceAPITest < Minitest::Test
       "user",
       "pass"
     )
-
-    @oauth = WooCommerce::API.new(
-      "http://dev.test/",
-      "user",
-      "pass"
-    )
   end
 
   def test_basic_auth_get
@@ -77,18 +71,5 @@ class WooCommerceAPITest < Minitest::Test
 
     assert_equal 202, response.code
     assert_equal '{"message":"Permanently deleted product"}', response.body
-  end
-
-  def test_adding_query_params
-    url = @oauth.send(:add_query_params, "foo.com", filter: { sku: "123" }, order: "created_at")
-
-    assert_equal url, Addressable::URI.encode("foo.com?filter[sku]=123&order=created_at")
-  end
-
-  def test_invalid_signature_method
-    client = WooCommerce::API.new("http://dev.test/", "user", "pass", signature_method: "GARBAGE")
-    assert_raises WooCommerce::OAuth::InvalidSignatureMethodError do
-      client.get "products"
-    end
   end
 end


### PR DESCRIPTION
Hides sensitive when using "inspect" on the API client. Prevents accidental exposure of sensitive information in log files or the console.

Bump to version 1.5.3